### PR TITLE
Started release notes for 2.1.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,6 @@ paginate: 5
 paginate_path: "blog/page:num"
 permalink: /blog/:categories/:year/:month/:day/:title
 relative_permalinks: false
-latest_version: 2.1.1
-latest_version_date: 2018-08-16
+latest_version: 2.1.2
+latest_version_date: 2019-02-07
 latest_snapshot: 2.2.0-SNAPSHOT

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -72,6 +72,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Release Notes<strong class="caret"></strong></a>
                     <ul class="dropdown-menu">
                         <!-- only keep the release notes for supported versions in this list -->
+                        <li><a href="/releasenotes/2.1.2">2.1.2</a></li>
                         <li><a href="/releasenotes/2.1.1">2.1.1</a></li>
                         <li><a href="/releasenotes/2.1.0">2.1.0</a></li>
                         <li><a href="/releasenotes/2.0.3">2.0.3</a></li>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -42,10 +42,6 @@
                 </div>
             </div>
 
-            <div id="keystonev3" class="alert alert-success">
-                <p>Read our blog posts about the <a href="/blog/2018/01/16/keystone-v3/">OpenStack Keystone V3</a> and <a href="/blog/2018/02/06/nova-neutron">Context linking & Neutron support for Nova</a> integrations released in jclouds <strong>2.1.0</strong>!</p>
-            </div>
-
             <div id="releasenews" class="alert alert-info">
                 <p>The <a href="/start/install/">latest version</a> is {{ site.latest_version }} released on {{ site.latest_version_date }}! Read the <a href="/releasenotes/{{ site.latest_version }}/">release notes</a>.</p>
             </div>

--- a/doap_jclouds.rdf
+++ b/doap_jclouds.rdf
@@ -37,6 +37,13 @@
     <category rdf:resource="http://projects.apache.org/category/library" />
     <release>
       <Version>
+        <name>Apache jclouds 2.1.2</name>
+        <created>2018-02-07</created>
+        <revision>2.1.2</revision>
+      </Version>
+    </release>
+    <release>
+      <Version>
         <name>Apache jclouds 2.1.1</name>
         <created>2018-08-16</created>
         <revision>2.1.1</revision>

--- a/releasenotes/2.1.2.md
+++ b/releasenotes/2.1.2.md
@@ -21,42 +21,63 @@ You can [read the official announcement here](https://s.apache.org/jclouds212). 
 
 New features in Apache jclouds 2.1.2 include:
 
-TODO
+* 1&1 Baremetal servers
+* EC2 r5, t3, and x1 instance types
+* GCS REGIONAL storage class
 
 ### Bugs and patches
 
+* [JCLOUDS-1330](https://issues.apache.org/jira/browse/JCLOUDS-1330) - Azure ARM orphaned networks not cleaned up when node deleted
+* [JCLOUDS-1331](https://issues.apache.org/jira/browse/JCLOUDS-1331) - Azure ARM orphaned resource groups are not cleaned up due to api caching/timing issue
+* [JCLOUDS-1339](https://issues.apache.org/jira/browse/JCLOUDS-1339) - Support launching an x1 EC2 instance
 * [JCLOUDS-1366](https://issues.apache.org/jira/browse/JCLOUDS-1366) - OutOfMemory when InputStream referencing to big file is used as payload
-* [JCLOUDS-1339](https://issues.apache.org/jira/browse/JCLOUDS-1339) -Support launching an x1 EC2 instance
+* [JCLOUDS-1386](https://issues.apache.org/jira/browse/JCLOUDS-1386) - 1&1 Baremetal servers
+* [JCLOUDS-1407](https://issues.apache.org/jira/browse/JCLOUDS-1407) - Add dimensiondata server API v2.7  support
 * [JCLOUDS-1419](https://issues.apache.org/jira/browse/JCLOUDS-1419) - Missing StorageClass REGIONAL for GCS buckets
 * [JCLOUDS-1431](https://issues.apache.org/jira/browse/JCLOUDS-1431) - Support AU geo for Live Tests
+* [JCLOUDS-1440](https://issues.apache.org/jira/browse/JCLOUDS-1440) - Add support for r5 instance types in AWS ec2
+* [JCLOUDS-1443](https://issues.apache.org/jira/browse/JCLOUDS-1443) - unable to resolve URI with complex host
+* [JCLOUDS-1447](https://issues.apache.org/jira/browse/JCLOUDS-1447) - S3 CopyObject requires x-amz-copy-source to be URL encoded
 * [JCLOUDS-1455](https://issues.apache.org/jira/browse/JCLOUDS-1455) - Update ParseResponse to log error details. Add ParseTests for Domain Objects in NetworkApi and ServerApi
+* [JCLOUDS-1456](https://issues.apache.org/jira/browse/JCLOUDS-1456) - Add dimensiondata ServerImage API v2.7 support
 * [JCLOUDS-1457](https://issues.apache.org/jira/browse/JCLOUDS-1457) - Add Clean Server operation to ServerApi
 * [JCLOUDS-1460](https://issues.apache.org/jira/browse/JCLOUDS-1460) - Add support for t3 instance types in AWS ec2
 * [JCLOUDS-1462](https://issues.apache.org/jira/browse/JCLOUDS-1462) - Upgrade Apache Http driver in response to CVE-2015-5262
 * [JCLOUDS-1463](https://issues.apache.org/jira/browse/JCLOUDS-1463) - MachineTypeToHardware throws exception when region has no available zone
 * [JCLOUDS-1464](https://issues.apache.org/jira/browse/JCLOUDS-1464) - Google Cloud Storage regions need updating
+* [JCLOUDS-1466](https://issues.apache.org/jira/browse/JCLOUDS-1466) - Azurecompute-arm listNodes doesn't work
 * [JCLOUDS-1467](https://issues.apache.org/jira/browse/JCLOUDS-1467) - Newly added c5 instanceType do not supports c5d series of AWS
 * [JCLOUDS-1468](https://issues.apache.org/jira/browse/JCLOUDS-1468) - Add missing fields on CloudStack usage API
-* [JCLOUDS-1477](https://issues.apache.org/jira/browse/JCLOUDS-1477) - B2 cannot upload small payloads when multipart specified
-* [JCLOUDS-1479](https://issues.apache.org/jira/browse/JCLOUDS-1479) - Swift API throws Exception when getting blob from containers
-* [JCLOUDS-1488](https://issues.apache.org/jira/browse/JCLOUDS-1488) - Filesystem list call with prefix is slow in large containers
-* [JCLOUDS-1443](https://issues.apache.org/jira/browse/JCLOUDS-1443) - unable to resolve URI with complex host
-* [JCLOUDS-1447](https://issues.apache.org/jira/browse/JCLOUDS-1447) - S3 CopyObject requires x-amz-copy-source to be URL encoded
-* [JCLOUDS-1466](https://issues.apache.org/jira/browse/JCLOUDS-1466) - Azurecompute-arm listNodes doesn't work
 * [JCLOUDS-1472](https://issues.apache.org/jira/browse/JCLOUDS-1472) - Multipart upload for AzureBlob fails when using InputStream for files greater than 32MB
 * [JCLOUDS-1474](https://issues.apache.org/jira/browse/JCLOUDS-1474) - [ARM] Enable Standard SKUs for Load Balancers and PublicIPs
+* [JCLOUDS-1477](https://issues.apache.org/jira/browse/JCLOUDS-1477) - B2 cannot upload small payloads when multipart specified
+* [JCLOUDS-1479](https://issues.apache.org/jira/browse/JCLOUDS-1479) - Swift API throws Exception when getting blob from containers
+* [JCLOUDS-1486](https://issues.apache.org/jira/browse/JCLOUDS-1486) - Fix NPE and Remove Nullable osImageKey From OsImage
+* [JCLOUDS-1488](https://issues.apache.org/jira/browse/JCLOUDS-1488) - Filesystem list call with prefix is slow in large containers
 
 The complete list of fixed issues and improvements can be found [here](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12314430&version=12343896).
 
 ## <a id="knownissues"></a> Known Issues
 
-TODO
+* There are a couple JIRA issues related to OpenStack endpoint and API version support: [JCLOUDS-773](https://issues.apache.org/jira/browse/JCLOUDS-773) and [JCLOUDS-1197](https://issues.apache.org/jira/browse/JCLOUDS-1197).
 
 ## <a id="credits"></a>Credits
 
 jclouds would like to thank everyone who contributed time and effort in order to make this release happen:
 
-TODO
+* [Mathieu Tortuyaux](https://github.com/tormath1) for fixing REST URLs with paths
+* [Markus Alexander Kuppe](https://github.com/lemmy) for adding EC2 x1 instances
+* [David Currie](https://github.com/davidcurrie) for fixing URL encoding for S3 x-amz-copy-source
+* [smedavaram75](https://github.com/smedavaram75) for adding GCS REGIONAL storage class
+* [Mahmoud Ismail](https://github.com/maismail) for annotating GCE sourceImage as @Nullable
+* [Oliver Gondža](https://github.com/olivergondza) for configuring sensitive Nova  logging
+* [Trent Schmidt](https://github.com/trentontrees) for adding t3 and other instances
+* [filecatalyst](https://github.com/filecatalyst) for updating GCS regions
+* [Joe Meiring](https://github.com/reptillicus) for fixing filesystem clear container options
+* [kazimazar](https://github.com/kazimazar) for adding c5d and m5d instances
+* [John McDonnell](https://github.com/mcdonnell-john) for adding missing options to CloudStack ListUsageRecords
+* [Simone Locci](https://github.com/pimuzzo) for fixing Azure compute listNodes
+* [Trần Tiến Đức](https://github.com/trantienduchn) for fixing Swift container metadata cache
 
 * Apache jclouds [PMC](http://people.apache.org/committers-by-project.html#jclouds-pmc) and community for verifying the release.
 * Check out who has been busy on [Open Hub](https://www.openhub.net/p/jclouds/contributors?query=&sort=latest_commit).

--- a/releasenotes/2.1.2.md
+++ b/releasenotes/2.1.2.md
@@ -63,6 +63,6 @@ TODO
 
 ## <a id="test"></a>Test Results
 
-Please see the discussion and the vote threads for live test results for 2.1.1:
+Please see the discussion and the vote threads for live test results for 2.1.2:
 
 * RC1 [vote](https://s.apache.org/jclouds212rc1vote) and [discussion](https://s.apache.org/jclouds212rc1discuss) threads.

--- a/releasenotes/2.1.2.md
+++ b/releasenotes/2.1.2.md
@@ -1,0 +1,68 @@
+---
+layout: releasenotes
+title: Release Notes for Version 2.1.2
+date: 2018-02-07 16:00:00
+release_notes: true
+permalink: /releasenotes/2.1.2/
+---
+
+1. [Introduction](#intro)
+1. [Release Highlights](#highlights)
+1. [Known Issues](#knownissues)
+1. [Credits](#credits)
+1. [Test Results](#test)
+
+## <a id="intro"></a>Introduction
+
+Apache jclouds 2.1.2 is the second bugfix release after jclouds 2.1.0 and comes with several bugfixes and performance improvements. 
+You can [read the official announcement here](https://s.apache.org/jclouds212). To get started with jclouds, please see the [jclouds installation guide](/start/install/).
+
+## <a id="highlights"></a>Release Highlights
+
+New features in Apache jclouds 2.1.2 include:
+
+TODO
+
+### Bugs and patches
+
+* [JCLOUDS-1366](https://issues.apache.org/jira/browse/JCLOUDS-1366) - OutOfMemory when InputStream referencing to big file is used as payload
+* [JCLOUDS-1339](https://issues.apache.org/jira/browse/JCLOUDS-1339) -Support launching an x1 EC2 instance
+* [JCLOUDS-1419](https://issues.apache.org/jira/browse/JCLOUDS-1419) - Missing StorageClass REGIONAL for GCS buckets
+* [JCLOUDS-1431](https://issues.apache.org/jira/browse/JCLOUDS-1431) - Support AU geo for Live Tests
+* [JCLOUDS-1455](https://issues.apache.org/jira/browse/JCLOUDS-1455) - Update ParseResponse to log error details. Add ParseTests for Domain Objects in NetworkApi and ServerApi
+* [JCLOUDS-1457](https://issues.apache.org/jira/browse/JCLOUDS-1457) - Add Clean Server operation to ServerApi
+* [JCLOUDS-1460](https://issues.apache.org/jira/browse/JCLOUDS-1460) - Add support for t3 instance types in AWS ec2
+* [JCLOUDS-1462](https://issues.apache.org/jira/browse/JCLOUDS-1462) - Upgrade Apache Http driver in response to CVE-2015-5262
+* [JCLOUDS-1463](https://issues.apache.org/jira/browse/JCLOUDS-1463) - MachineTypeToHardware throws exception when region has no available zone
+* [JCLOUDS-1464](https://issues.apache.org/jira/browse/JCLOUDS-1464) - Google Cloud Storage regions need updating
+* [JCLOUDS-1467](https://issues.apache.org/jira/browse/JCLOUDS-1467) - Newly added c5 instanceType do not supports c5d series of AWS
+* [JCLOUDS-1468](https://issues.apache.org/jira/browse/JCLOUDS-1468) - Add missing fields on CloudStack usage API
+* [JCLOUDS-1477](https://issues.apache.org/jira/browse/JCLOUDS-1477) - B2 cannot upload small payloads when multipart specified
+* [JCLOUDS-1479](https://issues.apache.org/jira/browse/JCLOUDS-1479) - Swift API throws Exception when getting blob from containers
+* [JCLOUDS-1488](https://issues.apache.org/jira/browse/JCLOUDS-1488) - Filesystem list call with prefix is slow in large containers
+* [JCLOUDS-1443](https://issues.apache.org/jira/browse/JCLOUDS-1443) - unable to resolve URI with complex host
+* [JCLOUDS-1447](https://issues.apache.org/jira/browse/JCLOUDS-1447) - S3 CopyObject requires x-amz-copy-source to be URL encoded
+* [JCLOUDS-1466](https://issues.apache.org/jira/browse/JCLOUDS-1466) - Azurecompute-arm listNodes doesn't work
+* [JCLOUDS-1472](https://issues.apache.org/jira/browse/JCLOUDS-1472) - Multipart upload for AzureBlob fails when using InputStream for files greater than 32MB
+* [JCLOUDS-1474](https://issues.apache.org/jira/browse/JCLOUDS-1474) - [ARM] Enable Standard SKUs for Load Balancers and PublicIPs
+
+The complete list of fixed issues and improvements can be found [here](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12314430&version=12343896).
+
+## <a id="knownissues"></a> Known Issues
+
+TODO
+
+## <a id="credits"></a>Credits
+
+jclouds would like to thank everyone who contributed time and effort in order to make this release happen:
+
+TODO
+
+* Apache jclouds [PMC](http://people.apache.org/committers-by-project.html#jclouds-pmc) and community for verifying the release.
+* Check out who has been busy on [Open Hub](https://www.openhub.net/p/jclouds/contributors?query=&sort=latest_commit).
+
+## <a id="test"></a>Test Results
+
+Please see the discussion and the vote threads for live test results for 2.1.1:
+
+* RC1 [vote](https://s.apache.org/jclouds212rc1vote) and [discussion](https://s.apache.org/jclouds212rc1discuss) threads.

--- a/releasenotes/2.1.2.md
+++ b/releasenotes/2.1.2.md
@@ -1,7 +1,7 @@
 ---
 layout: releasenotes
 title: Release Notes for Version 2.1.2
-date: 2018-02-07 16:00:00
+date: 2018-02-06 20:00:00
 release_notes: true
 permalink: /releasenotes/2.1.2/
 ---

--- a/releasenotes/index.md
+++ b/releasenotes/index.md
@@ -6,6 +6,7 @@ permalink: /releasenotes/
 
 The Release Notes and Javadocs for every major release of Apache jclouds are listed chronologically below.
 
+* [2.1.2](/releasenotes/2.1.2) | [Javadoc](/reference/javadoc/2.1.x/)
 * [2.1.1](/releasenotes/2.1.1) | [Javadoc](/reference/javadoc/2.1.x/)
 * [2.1.0](/releasenotes/2.1.0) | [Javadoc](/reference/javadoc/2.1.x/)
 * [2.0.3](/releasenotes/2.0.3) | [Javadoc](/reference/javadoc/2.0.x/)


### PR DESCRIPTION
Work started for the release notes for 2.1.2.

Things to be done:

* [x] Fix the release date to the real one once we have it.
* [x] Complete the TODOs (@gaul you've been more involved in the issues in this release. Mind having a look at the summary, known issues and contributors?).
* [ ] Once the announcement is out, get the permalink from `lists.apache.org` and generate a short url for it on `s.apache.org` using this ID: `https://s.apache.org/jclouds212` (the page already assumes that).