### PR TITLE
Add 2.5.0 to the menu and remove jclouds-labs links

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -72,6 +72,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Release Notes<strong class="caret"></strong></a>
                     <ul class="dropdown-menu">
                         <!-- only keep the release notes for supported versions in this list -->
+                        <li><a href="/releasenotes/2.5.0">2.5.0</a></li>
                         <li><a href="/releasenotes/2.4.0">2.4.0</a></li>
                         <li><a href="/releasenotes/2.3.0">2.3.0</a></li>
                         <li><a href="/releasenotes/2.2.1">2.2.1</a></li>

--- a/start/install.md
+++ b/start/install.md
@@ -37,21 +37,6 @@ The link in the Mirrors column below should display a list of available mirrors 
     <td><a href="https://www.apache.org/dist/jclouds/{{ site.latest_version }}/jclouds-{{ site.latest_version }}-source-release.tar.gz.sha512">SHA 512 checksum</td>
     <td><a href="https://www.apache.org/dist/jclouds/{{ site.latest_version }}/jclouds-{{ site.latest_version }}-source-release.tar.gz.asc">PGP signature</td>
 </tr>
-<tr>
-    <td><a href="https://www.apache.org/dyn/closer.lua/jclouds/{{ site.latest_version }}/jclouds-labs-{{ site.latest_version }}-source-release.tar.gz">jclouds-labs-{{ site.latest_version }}.tar.gz</a></td>
-    <td><a href="https://www.apache.org/dist/jclouds/{{ site.latest_version }}/jclouds-labs-{{ site.latest_version }}-source-release.tar.gz.sha512">SHA 512 checksum</td>
-    <td><a href="https://www.apache.org/dist/jclouds/{{ site.latest_version }}/jclouds-labs-{{ site.latest_version }}-source-release.tar.gz.asc">PGP signature</td>
-</tr>
-<tr>
-    <td><a href="https://www.apache.org/dyn/closer.lua/jclouds/{{ site.latest_version }}/jclouds-labs-aws-{{ site.latest_version }}-source-release.tar.gz">jclouds-labs-aws-{{ site.latest_version }}.tar.gz</a></td>
-    <td><a href="https://www.apache.org/dist/jclouds/{{ site.latest_version }}/jclouds-labs-aws-{{ site.latest_version }}-source-release.tar.gz.sha512">SHA 512 checksum</td>
-    <td><a href="https://www.apache.org/dist/jclouds/{{ site.latest_version }}/jclouds-labs-aws-{{ site.latest_version }}-source-release.tar.gz.asc">PGP signature</td>
-</tr>
-<tr>
-    <td><a href="https://www.apache.org/dyn/closer.lua/jclouds/{{ site.latest_version }}/jclouds-labs-openstack-{{ site.latest_version }}-source-release.tar.gz">jclouds-labs-openstack-{{ site.latest_version }}.tar.gz</a></td>
-    <td><a href="https://www.apache.org/dist/jclouds/{{ site.latest_version }}/jclouds-labs-openstack-{{ site.latest_version }}-source-release.tar.gz.sha512">SHA 512 checksum</td>
-    <td><a href="https://www.apache.org/dist/jclouds/{{ site.latest_version }}/jclouds-labs-openstack-{{ site.latest_version }}-source-release.tar.gz.asc">PGP signature</td>
-</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
The jclouds-labs links are broken because we're no longer releasing labs artifacts.
This PR removes those and adds the link to the 2.5.0 release notes to the dropdown menu in the nav bar.